### PR TITLE
kirby-fe-save-search-query

### DIFF
--- a/frontend/src/app/articles/page.tsx
+++ b/frontend/src/app/articles/page.tsx
@@ -1,6 +1,8 @@
+// Kirby Pascua | 22172362
+// mongodb connection articles
 "use client";
 
-import { useState, useEffect, useMemo, ChangeEvent } from "react";
+import { useState, useEffect, useMemo } from "react";
 import SortableTable from "@/components/Table/SortableTable";
 import ColumnSelector from "@/components/Table/ColumnSelector";
 
@@ -14,8 +16,7 @@ interface ArticlesInterface {
   status?: string;
   isbn?: string;
   moderatedBy?: string;
-  ratingSum?: number;
-  ratingCount?: number;
+  rating?: number | string;
   reason_for_decision?: string;
   volume?: string;
   number?: number;
@@ -33,14 +34,14 @@ const defaultVisibleColumns = {
   publisher: true,
   status: true,
   journal: true,
-  rating_ui: true,
+  rating: true,
   moderatedBy: true,
   practice: true,
-  claim: true,
+  claim: true
 };
 
 export default function ArticlesPage() {
-  const [articlesRaw, setArticlesRaw] = useState<ArticlesInterface[]>([]);
+  const [articles, setArticles] = useState<ArticlesInterface[]>([]);
   const [selectedStatus, setSelectedStatus] = useState<string>("All");
   const [selectedPractice, setSelectedPractice] = useState<string>("All");
   const [selectedClaim, setSelectedClaim] = useState<string>("All");
@@ -51,40 +52,48 @@ export default function ArticlesPage() {
   const [sortOrder, setSortOrder] = useState<"asc" | "desc">("asc");
   const [loading, setLoading] = useState(true);
   const [fetchError, setFetchError] = useState("");
-  const [visibleColumns, setVisibleColumns] = useState<Record<string, boolean>>(
-    () => {
-      if (typeof window !== "undefined") {
-        const saved = localStorage.getItem("columnVisibility");
-        return saved ? JSON.parse(saved) : defaultVisibleColumns;
-      }
-      return defaultVisibleColumns;
+
+  const [visibleColumns, setVisibleColumns] = useState<Record<string, boolean>>(() => {
+    if (typeof window !== 'undefined') {
+      const saved = localStorage.getItem('columnVisibility');
+      return saved ? JSON.parse(saved) : defaultVisibleColumns;
     }
-  );
+    return defaultVisibleColumns;
+  });
 
-  // Rating summary and user rating state
-  const [ratingSummaries, setRatingSummaries] = useState<
-    Record<string, { averageRating: number; ratingCount: number }>
-  >({});
-  const [userRatings, setUserRatings] = useState<Record<string, number | null>>(
-    {}
-  );
+  const [savedQueries, setSavedQueries] = useState<Record<string, string>>({});
+  const [newQueryName, setNewQueryName] = useState<string>("");
+  const [showSavePrompt, setShowSavePrompt] = useState<boolean>(false);
 
-  const getJwt = () => {
-    return typeof window !== "undefined" ? localStorage.getItem("token") : null;
+  useEffect(() => {
+    const saved = localStorage.getItem("savedSearchQueries");
+    if (saved) {
+      setSavedQueries(JSON.parse(saved));
+    }
+  }, []);
+
+  const handleSaveQuery = () => {
+    setShowSavePrompt(true);
   };
 
-  // Fetch articles
+  const confirmSaveQuery = () => {
+    if (!newQueryName.trim()) return;
+    const newSaved = { ...savedQueries, [newQueryName]: searchQuery };
+    setSavedQueries(newSaved);
+    localStorage.setItem("savedSearchQueries", JSON.stringify(newSaved));
+    setShowSavePrompt(false);
+    setNewQueryName("");
+  };
+
+  const loadSavedQuery = (query: string) => {
+    setSearchQuery(query);
+  };
+
   useEffect(() => {
     const fetchArticles = async () => {
       try {
-        const url =
-          `${process.env.NEXT_PUBLIC_SITE_URL}/articles` +
-          (searchQuery ? `?search=${encodeURIComponent(searchQuery)}` : "");
-        const response = await fetch(url, {
-          headers: {
-            Authorization: `Bearer ${getJwt() ?? ""}`,
-          },
-        });
+        const url = `http://localhost:3000/articles${searchQuery ? `?search=${encodeURIComponent(searchQuery)}` : ""}`;
+        const response = await fetch(url);
 
         if (!response.ok) {
           const errorText = await response.text();
@@ -96,33 +105,26 @@ export default function ArticlesPage() {
         const processedData = data.map((article: any) => {
           const formatDate = (dateString: string | { $date: string }) => {
             try {
-              const dateValue =
-                typeof dateString === "string" ? dateString : dateString?.$date;
+              const dateValue = typeof dateString === 'string' ? dateString : dateString?.$date;
               return new Date(dateValue).getFullYear().toString();
             } catch {
-              return "N/A";
+              return 'N/A';
             }
           };
 
-          const authorDisplay =
-            Array.isArray(article.author) && article.author.length > 0
-              ? article.author.join(", ")
-              : article.author || "Anonymous";
+          const authorDisplay = Array.isArray(article.author) && article.author.length > 0
+            ? article.author.join(', ')
+            : article.author || 'Anonymous';
 
-          const claimArray =
-            typeof article.claim === "string"
-              ? article.claim.split(",").map((id: string) => id.trim())
-              : Array.isArray(article.claim)
-              ? article.claim
-              : [];
+          const claimArray = typeof article.claim === 'string'
+            ? article.claim.split(',').map((id: string) => id.trim())
+            : Array.isArray(article.claim) ? article.claim : [];
 
-          interface PracticeArray extends Array<string> {}
-
-          const practiceArray: PracticeArray = Array.isArray(article.practice)
+          const practiceArray = Array.isArray(article.practice)
             ? article.practice
-            : typeof article.practice === "string" && article.practice !== "N/A"
-            ? article.practice.split(",").map((p: string) => p.trim())
-            : [];
+            : (typeof article.practice === 'string' && article.practice !== 'N/A'
+                ? article.practice.split(',').map(p => p.trim())
+                : []);
 
           return {
             ...article,
@@ -130,17 +132,18 @@ export default function ArticlesPage() {
             updated_date: formatDate(article.updated_date),
             moderated_date: formatDate(article.moderated_date),
             author: authorDisplay,
-            status: article.status || "Pending",
-            publisher: article.publisher || "Unknown Publisher",
-            claim: claimArray.join(", "),
+            status: article.status || 'Pending',
+            publisher: article.publisher || 'Unknown Publisher',
+            rating: article.rating ?? 'Not rated',
+            claim: claimArray.join(', '),
             practice: practiceArray,
           };
         });
 
-        setArticlesRaw(processedData);
+        setArticles(processedData);
         setFetchError("");
       } catch (error) {
-        console.error("Error fetching articles:", error);
+        console.error('Error fetching articles:', error);
         setFetchError("Failed to load articles. Please try again later.");
       } finally {
         setLoading(false);
@@ -149,178 +152,41 @@ export default function ArticlesPage() {
     fetchArticles();
   }, [searchQuery]);
 
-  // Fetch ratings for all articles
-  useEffect(() => {
-    if (loading || articlesRaw.length === 0) return;
-
-    const fetchRatingsForAll = async () => {
-      const jwt = getJwt() ?? "";
-      const newSummaries: Record<
-        string,
-        { averageRating: number; ratingCount: number }
-      > = {};
-      const newUserRatings: Record<string, number | null> = {};
-
-      await Promise.all(
-        articlesRaw.map(async (article) => {
-          const aId = article._id;
-          try {
-            // Summary
-            const summaryResp = await fetch(
-              `${process.env.NEXT_PUBLIC_SITE_URL}/articles/${aId}/rating/summary`,
-              {
-                headers: {
-                  Authorization: `Bearer ${jwt}`,
-                },
-              }
-            );
-            if (summaryResp.ok) {
-              const summaryJson = await summaryResp.json();
-              newSummaries[aId] = {
-                averageRating: summaryJson.averageRating,
-                ratingCount: summaryJson.ratingCount,
-              };
-            } else {
-              newSummaries[aId] = { averageRating: 0, ratingCount: 0 };
-            }
-          } catch (e) {
-            newSummaries[aId] = { averageRating: 0, ratingCount: 0 };
-          }
-
-          try {
-            // User's own rating
-            const userRatingResp = await fetch(
-              `${process.env.NEXT_PUBLIC_SITE_URL}/articles/${aId}/rating`,
-              {
-                headers: {
-                  Authorization: `Bearer ${jwt}`,
-                },
-              }
-            );
-            if (userRatingResp.ok) {
-              if (userRatingResp.status === 204) {
-                newUserRatings[aId] = null;
-              } else {
-                const text = await userRatingResp.text();
-                if (!text) {
-                  newUserRatings[aId] = null;
-                } else {
-                  const val = JSON.parse(text);
-                  newUserRatings[aId] = val === null ? null : Number(val);
-                }
-              }
-            } else {
-              newUserRatings[aId] = null;
-            }
-          } catch (e) {
-            newUserRatings[aId] = null;
-          }
-        })
-      );
-
-      setRatingSummaries(newSummaries);
-      setUserRatings(newUserRatings);
-    };
-
-    fetchRatingsForAll();
-  }, [loading, articlesRaw]);
-
-  // Handle rating change
-  const handleRatingChange = async (articleId: string, newValue: number) => {
-    const jwt = getJwt() ?? "";
-    try {
-      const resp = await fetch(
-        `${process.env.NEXT_PUBLIC_SITE_URL}/articles/${articleId}/rating`,
-        {
-          method: "PUT",
-          headers: {
-            "Content-Type": "application/json",
-            Authorization: `Bearer ${jwt}`,
-          },
-          body: JSON.stringify({ value: newValue }),
-        }
-      );
-      if (!resp.ok) {
-        const txt = await resp.text();
-        console.error("Failed to set rating:", txt);
-        return;
-      }
-      const updated = await resp.json();
-      setUserRatings((prev) => ({
-        ...prev,
-        [articleId]: newValue,
-      }));
-      setRatingSummaries((prev) => ({
-        ...prev,
-        [articleId]: {
-          averageRating: updated.averageRating,
-          ratingCount: updated.ratingCount,
-        },
-      }));
-    } catch (e) {
-      console.error("Error when submitting rating:", e);
-    }
-  };
-
-  // Column visibility toggle
   const toggleColumnVisibility = (column: string) => {
-    setVisibleColumns((prev) => {
-      const newVisibility = { ...prev, [column]: !prev[column] };
-      localStorage.setItem("columnVisibility", JSON.stringify(newVisibility));
+    setVisibleColumns(prev => {
+      const newVisibility = {...prev, [column]: !prev[column]};
+      localStorage.setItem('columnVisibility', JSON.stringify(newVisibility));
       return newVisibility;
     });
   };
 
-  // Filter options
   const statusOptions = Array.from(
-    new Set(
-      articlesRaw
-        .map((article) => article.status)
-        .filter((status) => status && status !== "Unknown")
-    )
+    new Set(articles.map(a => a.status).filter(s => s && s !== 'Unknown'))
   );
 
   const practiceOptions = Array.from(
-    new Set(
-      articlesRaw
-        .flatMap((article) => article.practice || [])
-        .filter((practice) => practice && practice !== "N/A")
-    )
+    new Set(articles.flatMap(a => a.practice || []).filter(p => p && p !== 'N/A'))
   );
 
   const claimOptions = useMemo(() => {
-    if (selectedPractice === "All") {
-      return [];
-    }
-    const practiceClaims = new Set<string>();
-    articlesRaw.forEach((article) => {
-      if (
-        article.practice &&
-        article.practice.includes(selectedPractice) &&
-        article.claim
-      ) {
-        article.claim.split(",").forEach((claim) => {
-          practiceClaims.add(claim.trim());
-        });
+    if (selectedPractice === "All") return [];
+    const claimSet = new Set<string>();
+    articles.forEach(a => {
+      if (a.practice?.includes(selectedPractice) && a.claim) {
+        a.claim.split(',').forEach(c => claimSet.add(c.trim()));
       }
     });
-    return Array.from(practiceClaims).filter((c) => c.length > 0);
-  }, [articlesRaw, selectedPractice]);
+    return Array.from(claimSet);
+  }, [articles, selectedPractice]);
 
-  // Year validation
-  const validateYears = (start: string, end: string): boolean => {
-    const startNum = parseInt(start);
-    const endNum = parseInt(end);
-
-    if (start && end && startNum > endNum) {
+  const validateYears = (start: string, end: string) => {
+    const s = parseInt(start), e = parseInt(end);
+    if (start && end && s > e) {
       setErrorMessage("End year cannot be earlier than start year");
       return false;
     }
-    if (
-      (start && startNum < 1900) ||
-      (end && endNum > new Date().getFullYear())
-    ) {
-      setErrorMessage("Years must be between 1900 and current year");
+    if ((start && s < 1900) || (end && e > new Date().getFullYear())) {
+      setErrorMessage("Years must be between 1900 and the current year");
       return false;
     }
     setErrorMessage("");
@@ -328,57 +194,24 @@ export default function ArticlesPage() {
   };
 
   useEffect(() => {
-    if (startYear || endYear) {
-      validateYears(startYear, endYear);
-    } else {
-      setErrorMessage("");
-    }
+    if (startYear || endYear) validateYears(startYear, endYear);
   }, [startYear, endYear]);
 
-  useEffect(() => {
-    setSelectedClaim("All");
-  }, [selectedPractice]);
+  useEffect(() => setSelectedClaim("All"), [selectedPractice]);
 
-  // Filtering and sorting
-  const filteredData = articlesRaw
-    .filter((article) => {
-      const matchesStatus =
-        selectedStatus === "All" || article.status === selectedStatus;
-      const matchesPractice =
-        selectedPractice === "All" ||
-        (article.practice && article.practice.includes(selectedPractice));
-      const matchesClaim =
-        selectedClaim === "All" ||
-        (article.claim &&
-          article.claim
-            .split(",")
-            .map((c) => c.trim())
-            .includes(selectedClaim));
-      const pubYear = article.published_date
-        ? parseInt(article.published_date)
-        : 0;
-      let matchesYear = true;
-      if (startYear && endYear) {
-        matchesYear =
-          pubYear >= parseInt(startYear) && pubYear <= parseInt(endYear);
-      }
-      const authorString = Array.isArray(article.author)
-        ? article.author.join(", ")
-        : article.author || "Unknown Author";
-      const matchesSearch =
-        article.title.toLowerCase().includes(searchQuery.toLowerCase()) ||
-        authorString.toLowerCase().includes(searchQuery.toLowerCase()) ||
-        (article.description &&
-          article.description
-            .toLowerCase()
-            .includes(searchQuery.toLowerCase()));
-
+  const filteredData = articles
+    .filter(a => {
+      const year = parseInt(a.published_date) || 0;
       return (
-        matchesStatus &&
-        matchesPractice &&
-        matchesClaim &&
-        matchesYear &&
-        matchesSearch
+        (selectedStatus === "All" || a.status === selectedStatus) &&
+        (selectedPractice === "All" || a.practice?.includes(selectedPractice)) &&
+        (selectedClaim === "All" || a.claim?.split(',').map(c => c.trim()).includes(selectedClaim)) &&
+        (!startYear || !endYear || (year >= parseInt(startYear) && year <= parseInt(endYear))) &&
+        (
+          a.title.toLowerCase().includes(searchQuery.toLowerCase()) ||
+          (Array.isArray(a.author) ? a.author.join(", ") : a.author || "").toLowerCase().includes(searchQuery.toLowerCase()) ||
+          a.description?.toLowerCase().includes(searchQuery.toLowerCase())
+        )
       );
     })
     .sort((a, b) =>
@@ -387,7 +220,6 @@ export default function ArticlesPage() {
         : (parseInt(b.published_date) || 0) - (parseInt(a.published_date) || 0)
     );
 
-  // Table headers
   const headers = [
     { key: "title", label: "Title" },
     { key: "author", label: "Author" },
@@ -395,104 +227,63 @@ export default function ArticlesPage() {
     { key: "publisher", label: "Publisher" },
     { key: "status", label: "Status" },
     { key: "journal", label: "Journal" },
-    { key: "rating_ui", label: "Rating" },
+    { key: "rating", label: "Rating" },
     { key: "moderatedBy", label: "Moderated By" },
     { key: "practice", label: "Practice" },
     { key: "claim", label: "Claims" },
   ];
 
-  if (loading) {
-    return <div className="container">Loading articles...</div>;
-  }
-
-  if (fetchError) {
-    return <div className="container error-message">{fetchError}</div>;
-  }
-
   return (
-    <div className="container mx-auto">
-      {/* Filters Section */}
-      <div className="filters flex flex-wrap gap-4 items-end bg-slate-100 p-4 rounded-lg shadow mb-6">
+    <div className="p-4 max-w-screen-xl mx-auto">
+      <div className="flex flex-wrap items-center gap-4 mb-6">
+        <button
+          type="button"
+          onClick={handleSaveQuery}
+          className="bg-blue-600 text-white px-4 py-2 rounded hover:bg-blue-700"
+        >
+          Save Current Search
+        </button>
+
+        <select
+          onChange={(e) => loadSavedQuery(savedQueries[e.target.value])}
+          className="border rounded px-2 py-1"
+        >
+          <option value="">-- Load Saved Search --</option>
+          {Object.entries(savedQueries).map(([name]) => (
+            <option key={name} value={name}>{name}</option>
+          ))}
+        </select>
+
         <input
           type="text"
-          placeholder="Search articles..."
+          placeholder="Search..."
           value={searchQuery}
           onChange={(e) => setSearchQuery(e.target.value)}
-          className="search-input px-3 py-2 rounded border border-slate-300 focus:outline-none focus:ring-2 focus:ring-blue-400 bg-white"
+          className="border rounded px-2 py-1 flex-1"
         />
+      </div>
 
-        <select
-          value={selectedStatus}
-          onChange={(e) => setSelectedStatus(e.target.value)}
-          className="px-3 py-2 rounded border border-slate-300 focus:outline-none focus:ring-2 focus:ring-blue-400 bg-white"
-        >
+      {/* Filters and controls */}
+      <div className="flex flex-wrap gap-4 mb-4">
+        <select value={selectedStatus} onChange={(e) => setSelectedStatus(e.target.value)} className="border rounded px-2 py-1">
           <option value="All">All Statuses</option>
-          {statusOptions.map((status, index) => (
-            <option key={`status-${index}`} value={status}>
-              {status}
-            </option>
-          ))}
+          {statusOptions.map((s, i) => <option key={i}>{s}</option>)}
         </select>
 
-        <select
-          value={selectedPractice}
-          onChange={(e) => setSelectedPractice(e.target.value)}
-          className="px-3 py-2 rounded border border-slate-300 focus:outline-none focus:ring-2 focus:ring-blue-400 bg-white"
-        >
+        <select value={selectedPractice} onChange={(e) => setSelectedPractice(e.target.value)} className="border rounded px-2 py-1">
           <option value="All">All Practices</option>
-          {practiceOptions.map((practice, index) => (
-            <option key={`practice-${index}`} value={practice}>
-              {practice}
-            </option>
-          ))}
+          {practiceOptions.map((p, i) => <option key={i}>{p}</option>)}
         </select>
 
-        <select
-          value={selectedClaim}
-          onChange={(e) => setSelectedClaim(e.target.value)}
-          disabled={selectedPractice === "All" || claimOptions.length === 0}
-          className="px-3 py-2 rounded border border-slate-300 focus:outline-none focus:ring-2 focus:ring-blue-400 bg-white"
-        >
-          <option value="All">
-            {selectedPractice === "All"
-              ? "Select a practice first"
-              : claimOptions.length === 0
-              ? "No claims for this practice"
-              : "All Claims"}
-          </option>
-          {claimOptions.map((claim, index) => (
-            <option key={`claim-${index}`} value={claim}>
-              {claim}
-            </option>
-          ))}
+        <select value={selectedClaim} onChange={(e) => setSelectedClaim(e.target.value)} disabled={selectedPractice === "All"} className="border rounded px-2 py-1">
+          <option value="All">All Claims</option>
+          {claimOptions.map((c, i) => <option key={i}>{c}</option>)}
         </select>
 
-        <div className="year-inputs flex gap-2">
-          <input
-            type="number"
-            placeholder="Start year"
-            value={startYear}
-            onChange={(e) => setStartYear(e.target.value)}
-            min="1900"
-            max={new Date().getFullYear()}
-            className="px-3 py-2 rounded border border-slate-300 focus:outline-none focus:ring-2 focus:ring-blue-400 bg-white w-28"
-          />
-          <input
-            type="number"
-            placeholder="End year"
-            value={endYear}
-            onChange={(e) => setEndYear(e.target.value)}
-            min="1900"
-            max={new Date().getFullYear()}
-            className="px-3 py-2 rounded border border-slate-300 focus:outline-none focus:ring-2 focus:ring-blue-400 bg-white w-28"
-          />
-        </div>
+        <input type="number" placeholder="Start Year" value={startYear} onChange={(e) => setStartYear(e.target.value)} className="border rounded px-2 py-1 w-24" />
+        <input type="number" placeholder="End Year" value={endYear} onChange={(e) => setEndYear(e.target.value)} className="border rounded px-2 py-1 w-24" />
 
-        <select
-          value={sortOrder}
-          onChange={(e) => setSortOrder(e.target.value as "asc" | "desc")}
-          className="px-3 py-2 rounded border border-slate-300 focus:outline-none focus:ring-2 focus:ring-blue-400 bg-white"
-        >
+        <select value={sortOrder} onChange={(e) => setSortOrder(e.target.value as "asc" | "desc")} className="border rounded px-2 py-1">
           <option value="asc">Oldest First</option>
           <option value="desc">Newest First</option>
         </select>
@@ -504,60 +295,34 @@ export default function ArticlesPage() {
         />
       </div>
 
-      {errorMessage && <div className="error-message">{errorMessage}</div>}
-
-      {filteredData.length === 0 && searchQuery && (
-        <div className="no-results">
-          No articles found matching "{searchQuery}"
-        </div>
-      )}
-
-      {filteredData.length === 0 && !searchQuery && (
-        <div className="no-results">No articles found</div>
-      )}
-
-      {filteredData.length > 0 && (
+      {errorMessage && <p className="text-red-600">{errorMessage}</p>}
+      {filteredData.length === 0 ? (
+        <p>No results found.</p>
+      ) : (
         <SortableTable
           headers={headers}
-          data={filteredData.map((article) => ({
-            ...article,
-            practice: article.practice?.join(", ") || "N/A",
-            rating_ui: (
-              <div>
-                {/* Dropdown for selecting 1–5 stars */}
-                <select
-                  value={userRatings[article._id] ?? ""}
-                  onChange={(e: ChangeEvent<HTMLSelectElement>) => {
-                    const val =
-                      e.target.value === "" ? null : Number(e.target.value);
-                    if (val !== null) {
-                      handleRatingChange(article._id, val);
-                    }
-                  }}
-                >
-                  <option value="">Your Rating</option>
-                  {[1, 2, 3, 4, 5].map((n) => (
-                    <option key={n} value={n}>
-                      {n} star{n > 1 ? "s" : ""}
-                    </option>
-                  ))}
-                </select>
-                <div style={{ fontSize: "0.8em", marginTop: "4px" }}>
-                  Avg:{" "}
-                  {ratingSummaries[article._id]
-                    ? ratingSummaries[article._id].averageRating.toFixed(1)
-                    : "0.0"}{" "}
-                  ({ratingSummaries[article._id]?.ratingCount ?? 0} vote
-                  {(ratingSummaries[article._id]?.ratingCount ?? 0) === 1
-                    ? ""
-                    : "s"}
-                  )
-                </div>
-              </div>
-            ),
-          }))}
+          data={filteredData.map(a => ({ ...a, practice: a.practice?.join(", ") || "N/A" }))}
           visibleColumns={visibleColumns}
         />
+      )}
+
+      {showSavePrompt && (
+        <div className="fixed top-0 left-0 w-full h-full bg-black bg-opacity-40 flex justify-center items-center z-50">
+          <div className="bg-white rounded-lg shadow-lg p-6 w-96">
+            <h2 className="text-lg font-semibold mb-4">Save Search</h2>
+            <input
+              type="text"
+              placeholder="Search name"
+              value={newQueryName}
+              onChange={(e) => setNewQueryName(e.target.value)}
+              className="w-full border rounded px-3 py-2 mb-4"
+            />
+            <div className="flex justify-end gap-2">
+              <button onClick={() => setShowSavePrompt(false)} className="px-4 py-2 bg-gray-300 rounded hover:bg-gray-400">Cancel</button>
+              <button onClick={confirmSaveQuery} className="px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700">Save</button>
+            </div>
+          </div>
+        </div>
       )}
     </div>
   );


### PR DESCRIPTION
Key Changes:
This update allows users to save custom search queries and easily reuse them later. A new “Save Current Search” button has been added with clear visual styling using Tailwind. When clicked, the user is prompted via a modal-style input to name their search query. Saved queries persist in localStorage and are displayed in a dropdown menu when the user returns to the page. Selecting a saved query reloads the associated search parameters including text input, status, practice, claim, and publication year range. This improves usability for users who frequently filter articles and want to return to their preferred search combinations quickly and efficiently.